### PR TITLE
OpenBSD and newer base version

### DIFF
--- a/kqueue.cabal
+++ b/kqueue.cabal
@@ -21,7 +21,7 @@ Library
   Hs-Source-Dirs:      src
   Exposed-modules:     System.KQueue
                        System.KQueue.HighLevel
-  Build-depends:       base >= 4.0 && < 4.15
+  Build-depends:       base >= 4.0 && < 5
                      , directory >= 1.0 && < 1.4
                      , filepath >= 1.1 && < 1.5
                      , mtl >= 1.1 && < 2.3

--- a/src/System/KQueue.chs
+++ b/src/System/KQueue.chs
@@ -19,6 +19,7 @@ module System.KQueue
   , KQueueException
   ) where
 
+#include <sys/types.h>
 #include <sys/time.h>
 #include <sys/event.h>
 

--- a/src/System/KQueue.chs
+++ b/src/System/KQueue.chs
@@ -167,7 +167,7 @@ typedef struct kevent kevent_t;
 
 instance Storable KEvent where
   sizeOf _ = {#sizeof kevent_t #}
-  alignment _ = 24
+  alignment _ = 32
   peek e = KEvent <$>                                     ({#get kevent_t->ident  #} e)
                   <*> fmap (toEnum . fromIntegral)        ({#get kevent_t->filter #} e)
                   <*> fmap (bitmaskToEnum . fromIntegral) ({#get kevent_t->flags  #} e)

--- a/src/System/KQueue.chs
+++ b/src/System/KQueue.chs
@@ -56,6 +56,7 @@ import Foreign.C           ( CInt (..)
 import Foreign.C           ( CInt )
 #endif
 import Foreign.C           ( CLong
+                           , CLLong
                            , CTime
                            , CULong
                            )
@@ -77,7 +78,7 @@ data KEvent = KEvent
   , evfilter :: Filter  -- ^ The kernel filter (type of event).
   , flags    :: [Flag]  -- ^ Actions to perform on the event.
   , fflags   :: [FFlag] -- ^ Filter-specific flags.
-  , data_    :: CLong   -- ^ Filter-specific data value.
+  , data_    :: CLLong   -- ^ Filter-specific data value.
   , udata    :: Ptr ()  -- ^ User-defined data, passed through unchanged.
   } deriving (Show, Eq)
 
@@ -92,8 +93,9 @@ enum Filter
   , EvfiltProc = EVFILT_PROC
   , EvfiltSignal = EVFILT_SIGNAL
   , EvfiltTimer = EVFILT_TIMER
-// Not on Mac OS X
-// , EvfiltUser = EVFILT_USER
+#ifdef EVFILT_USER
+  , EvfiltUser = EVFILT_USER
+#endif
   };
 #endc
 
@@ -105,8 +107,9 @@ enum Flag
   { EvAdd      = EV_ADD
   , EvEnable   = EV_ENABLE
   , EvDisable  = EV_DISABLE
-// Not on Mac OS X
-//  , EvDispatch = EV_DISPATCH
+#ifdef EV_DISPATCH
+  , EvDispatch = EV_DISPATCH
+#endif
   , EvDelete   = EV_DELETE
   , EvReceipt  = EV_RECEIPT
   , EvOneshot  = EV_ONESHOT
@@ -128,13 +131,18 @@ enum FFlag
   , NoteLink   = NOTE_LINK
   , NoteRename = NOTE_RENAME
   , NoteRevoke = NOTE_REVOKE
-// Seems to have the same value as NoteDelete
-//  , NoteLowat  = NOTE_LOWAT
+#if NOTE_LOWA != NOTE_DELETE
+  , NoteLowat  = NOTE_LOWAT
+#endif
   , NoteExit   = NOTE_EXIT
   , NoteFork   = NOTE_FORK
   , NoteExec   = NOTE_EXEC
+#ifdef NOTE_SIGNAL
   , NoteSignal = NOTE_SIGNAL
-//  , NoteReap   = NOTE_REAP
+#endif
+#ifdef NOTE_REAP
+  , NoteReap   = NOTE_REAP
+#endif
   };
 #endc
 

--- a/src/System/KQueue.chs
+++ b/src/System/KQueue.chs
@@ -19,7 +19,6 @@ module System.KQueue
   , KQueueException
   ) where
 
-#include <sys/types.h>
 #include <sys/time.h>
 #include <sys/event.h>
 


### PR DESCRIPTION
These changes have allowed me to compile this on OpenBSD with ghc 9.2

I am unsure if this has broken compatibility with macOS. Specifically, switching CLong to CLLong. 